### PR TITLE
replaced deprecated addstream event handler

### DIFF
--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -173,7 +173,7 @@ function makeConnection() {
     ],
   });
   myPeerConnection.addEventListener("icecandidate", handleIce);
-  myPeerConnection.addEventListener("addstream", handleAddStream);
+  myPeerConnection.addEventListener("track", handleTrackEvent);
   myStream
     .getTracks()
     .forEach((track) => myPeerConnection.addTrack(track, myStream));
@@ -184,7 +184,7 @@ function handleIce(data) {
   socket.emit("ice", data.candidate, roomName);
 }
 
-function handleAddStream(data) {
+function handleTrackEvent(data) {
   const peerFace = document.getElementById("peerFace");
-  peerFace.srcObject = data.stream;
+  peerFace.srcObject = data.streams[0];
 }


### PR DESCRIPTION
Deprecated addstream event handler: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onaddstream
Replaced by track event handler: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/track_event

It fixes the bug where the peer stream would not show on iPhone X (Safari 14.8.1, Brave 1.32.1)